### PR TITLE
Update docker.yaml

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,15 +1,15 @@
 name: Docker
 
 ## add something in here to choose when this workflow runs
-#on:
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to use (defaults to "test")'
+        default: "test"
 #  push:
 #    branches:
 #      - main
-#  workflow_dispatch:
-#    inputs:
-#      tag:
-#        description: 'Tag to use (defaults to "test")'
-#        default: "test"
 
 permissions:
   id-token: write


### PR DESCRIPTION
Alright this is a weird one. AFAIK the github CI workflows can be made to execute on a test branch, but only if the schedule on `main` allows it to?

Case in point - in a repository built from this template, there is no 'workflow_dispatch' for the docker build, it's commented out because it wasn't changed since copying this template. This means that on main the docker build can't be manually triggered. 

On a test branch, the docker workflow _also_ can't be triggered, because `main` won't let it (the workflow on main doesn't think it should be run on a schedule)

https://github.com/populationgenomics/cpg-flow-exomiser/blob/299c8bc2b2d33a2a96accd05bed1b73c11023a2a/.github/workflows/docker.yaml

By adding workflow_dispatch into this template, derived repositories will be able to build and release test builds to validate performance on