### PR TITLE
Docker destination images-dev, not images-tmp

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,7 +31,7 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
       # TODO(you) choose the name for your image
       IMAGE_NAME: workflow_name
-      DOCKER_TMP: australia-southeast1-docker.pkg.dev/cpg-common/images-tmp
+      DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
       DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images
     steps:
       - uses: actions/checkout@v4
@@ -56,23 +56,23 @@ jobs:
 
       - name: build
         run: |
-          docker build . -f Dockerfile --tag ${{env.IMAGE_NAME}}:${{ github.sha }}
+          docker build . -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }}
 
       # TODO(you) choose how/when to push the resulting image
       - name: Push from merge to main
         if: ${{ github.ref_name == 'main' }}
         run: |
-          docker tag ${{env.IMAGE_NAME}}:${{ github.sha }} ${{env.DOCKER_MAIN}}/${{env.IMAGE_NAME}}:$VERSION
-          docker push ${{env.DOCKER_MAIN}}/${{env.IMAGE_NAME}}:$VERSION
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:$VERSION
+          docker push $DOCKER_MAIN/$IMAGE_NAME:$VERSION
 
       - name: Push manually triggered build
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' }}
         run: |
-          docker tag ${{env.IMAGE_NAME}}:${{ github.sha }} ${{env.DOCKER_TMP}}/${{env.IMAGE_NAME}}:${{github.event.inputs.tag}}
-          docker push ${{env.DOCKER_TMP}}/${{env.IMAGE_NAME}}:${{github.event.inputs.tag}}
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
+          docker push $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
 
       - name: Push Pull Request triggered build
         if: ${{ github.event_name == 'pull_request' && github.ref_name != 'main' }}
         run: |
-          docker tag ${{env.IMAGE_NAME}}:${{ github.sha }} ${{env.DOCKER_TMP}}/${{env.IMAGE_NAME}}:PR_${{github.event.number}}
-          docker push ${{env.DOCKER_TMP}}/${{env.IMAGE_NAME}}:PR_${{github.event.number}}
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:PR_${{github.event.number}}
+          docker push $DOCKER_DEV/$IMAGE_NAME:PR_${{github.event.number}}


### PR DESCRIPTION
# Purpose

  - Images-tmp is being discontinued in favour of images-dev with a fixed lifecycle

## Proposed Changes

  - Update `images-tmp` to `images-dev`
  - Remove some extra boilerplate brackets round environment variables
